### PR TITLE
Allow all-Orchestration on Promises

### DIFF
--- a/rxjava-promises/rxjava-promises-groovy/src/main/groovy/com/darylteo/rx/promises/groovy/Promise.groovy
+++ b/rxjava-promises/rxjava-promises-groovy/src/main/groovy/com/darylteo/rx/promises/groovy/Promise.groovy
@@ -1,8 +1,9 @@
 package com.darylteo.rx.promises.groovy
 
-import com.darylteo.rx.promises.AbstractPromise
 import rx.functions.Action0
 import rx.functions.Func1
+
+import com.darylteo.rx.promises.AbstractPromise
 
 public class Promise<T> extends AbstractPromise<T> {
   public Promise() {
@@ -28,7 +29,36 @@ public class Promise<T> extends AbstractPromise<T> {
   public <O> Promise<O> fin(Closure<O> onFinally) {
     return this.promise(null, null, onFinally);
   }
+  
+  
+  public static Promise<List> all(final Promise... promises) {
+    return AbstractPromise._all(Promise.class, promises);
+  }
+  
+  /**
+   * Combines multiple promises into a single promise that is resolved when all of the input promises are resolved
+   *
+   * @param promises array of promises
+   * @return Returns a single promise that will be resolved with a list of values,
+   *         each value corresponding to the promise at the same index in the promises array.
+   *         If any of the promises is resolved with a rejection, this resulting promise will
+   *         be rejected with a list of values/exceptions.
+   */
+  public static Promise<List> all(long timeout, final Promise... promises) {
+    return AbstractPromise._all(Promise.class, timeout, promises);
+  }
 
+  /**
+   * Combines multiple promises into a single promise that is resolved when all of the input promises are resolved,
+   * before an timeout exception occurs. In case of timeout, result promise will be rejected with an TimeoutException
+   *
+   * @param timeout timeout in milliseconds
+   * @param promises array of promises
+   * @return Returns a single promise that will be resolved with a list of values,
+   *         each value corresponding to the promise at the same index in the promises array.
+   *         If any of the promises is resolved with a rejection, this resulting promise will
+   *         be rejected with a list of values/exceptions.
+   */
   private <O> Promise<O> promise(Closure<O> onFulfilled, Closure<O> onRejected, Closure<O> onFinally) {
     return (Promise<O>) super._then(onFulfilled as Func1<T, O>, onRejected as Func1<T, O>, onFinally as Action0<?>)
   }

--- a/rxjava-promises/rxjava-promises-groovy/src/test/groovy/com/darylteo/rx/promises/groovy/tests/PromisesTestGroovy.groovy
+++ b/rxjava-promises/rxjava-promises-groovy/src/test/groovy/com/darylteo/rx/promises/groovy/tests/PromisesTestGroovy.groovy
@@ -1,12 +1,13 @@
 package com.darylteo.rx.promises.groovy.tests
 
-import com.darylteo.rx.promises.groovy.Promise
-import org.junit.Test
+import static org.junit.Assert.*
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-import static org.junit.Assert.*
+import org.junit.Test
+
+import com.darylteo.rx.promises.groovy.Promise
 
 /* http://promises-aplus.github.io/promises-spec/ */
 
@@ -114,6 +115,57 @@ class PromisesTestGroovy {
     assertTrue invalids.empty
     assertEquals 0, latch.count
   }
+  
+  @Test
+  public void testPromiseAll() throws InterruptedException {
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    Promise p1 = new Promise();
+    Promise p2 = new Promise();
+
+    def result;
+    println "start : " + result
+
+    Promise.all(p1, p2).then { l ->
+        result = 0;
+        println "all done : " + result
+        l.each {
+          result += (Integer) it;
+          println "result : " + result
+        }
+      };
+
+    p1.fulfill(2);
+    p2.fulfill(3);
+
+    latch.await(2, TimeUnit.SECONDS);
+    assertEquals(result, 5);
+  }
+
+  @Test
+  public void testPromiseAllReject() throws InterruptedException {
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    Promise p1 = new Promise();
+    Promise p2 = new Promise();
+    
+    def result;
+
+    Promise.all(p1, p2).then( { List l ->
+      // not used for this test
+    }, { Exception e ->
+      result = e;
+    });
+
+    p1.fulfill(2);
+    String reason = "Reject Reason";
+    p2.reject(reason);
+
+    latch.await(2, TimeUnit.SECONDS);
+    assertTrue(result instanceof Exception);
+    assertTrue(((Exception) result).getMessage().contains(reason));
+  }
+
 
 
   private Promise<String> makePromise(String message) {
@@ -137,4 +189,6 @@ class PromisesTestGroovy {
 
     return p
   }
+  
+  
 }

--- a/rxjava-promises/rxjava-promises-java/src/main/java/com/darylteo/rx/promises/java/Promise.java
+++ b/rxjava-promises/rxjava-promises-java/src/main/java/com/darylteo/rx/promises/java/Promise.java
@@ -1,10 +1,16 @@
 package com.darylteo.rx.promises.java;
 
-import com.darylteo.rx.promises.AbstractPromise;
-import com.darylteo.rx.promises.java.functions.*;
+import java.util.List;
+
 import rx.Observable;
 import rx.functions.Function;
-import rx.subjects.ReplaySubject;
+
+import com.darylteo.rx.promises.AbstractPromise;
+import com.darylteo.rx.promises.java.functions.FinallyAction;
+import com.darylteo.rx.promises.java.functions.FinallyFunction;
+import com.darylteo.rx.promises.java.functions.PromiseAction;
+import com.darylteo.rx.promises.java.functions.PromiseFunction;
+import com.darylteo.rx.promises.java.functions.RepromiseFunction;
 
 /**
  * A Promise represents a request that will be fulfilled sometime in the future, most usually by an asynchrous task executed on the Vert.x Event Loop. It allows you to assign handlers to deal with the return results of asynchronus tasks, and to flatten "pyramids of doom" or "callback hell".
@@ -115,6 +121,37 @@ public class Promise<T> extends AbstractPromise<T> {
   public Promise<T> fin(FinallyAction onFinally) {
     return this.promise(null, null, onFinally);
   }
+  
+  /**
+   * Combines multiple promises into a single promise that is resolved when all of the input promises are resolved
+   *
+   * @param promises array of promises
+   * @return Returns a single promise that will be resolved with a list of values, 
+   *         each value corresponding to the promise at the same index in the promises array. 
+   *         If any of the promises is resolved with a rejection, this resulting promise will 
+   *         be rejected with a list of values/exceptions.
+   */
+  @SuppressWarnings({"rawtypes" })
+  public static Promise<List> all(final Promise... promises) {
+    return (Promise<List>) AbstractPromise._all(Promise.class, promises);
+  }
+  
+  /**
+   * Combines multiple promises into a single promise that is resolved when all of the input promises are resolved, 
+   * before an timeout exception occurs. In case of timeout, result promise will be rejected with an TimeoutException
+   *
+   * @param timeout timeout in milliseconds
+   * @param promises array of promises
+   * @return Returns a single promise that will be resolved with a list of values, 
+   *         each value corresponding to the promise at the same index in the promises array. 
+   *         If any of the promises is resolved with a rejection, this resulting promise will 
+   *         be rejected with a list of values/exceptions.
+   */
+  @SuppressWarnings({"rawtypes" })
+  public static Promise<List> all(long timeout, final Promise... promises) {
+    return (Promise<List>) AbstractPromise._all(Promise.class, timeout, promises);
+  }
+
 
   @SuppressWarnings("unchecked")
   protected <O> Promise<O> promise(Function onFulfilled, Function onRejected, Function onFinally) {

--- a/rxjava-promises/rxjava-promises-java/src/test/java/com/darylteo/rx/promises/test/PromiseRxJavaTests.java
+++ b/rxjava-promises/rxjava-promises-java/src/test/java/com/darylteo/rx/promises/test/PromiseRxJavaTests.java
@@ -1,16 +1,20 @@
 package com.darylteo.rx.promises.test;
 
-import com.darylteo.rx.promises.java.Promise;
-import com.darylteo.rx.promises.java.functions.PromiseAction;
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.junit.Test;
+
 import rx.Observable;
 import rx.functions.Action1;
 import rx.functions.Func1;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
+import com.darylteo.rx.promises.java.Promise;
+import com.darylteo.rx.promises.java.functions.PromiseAction;
 
 public class PromiseRxJavaTests {
 
@@ -79,6 +83,117 @@ public class PromiseRxJavaTests {
 
     latch.await(2l, TimeUnit.SECONDS);
     assertEquals("World", result.value);
+  }
+  
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  @Test
+  public void testPromiseAll() throws InterruptedException {
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    Promise p1 = new Promise();
+    Promise p2 = new Promise();
+
+    final Result<Integer> result = new Result<Integer>();
+
+    Promise.all(p1, p2).then(new PromiseAction<List>() {
+      public void call(List l) {
+        result.value = 0;
+        for (Object object : l) {
+          result.value += (Integer) object;
+        }
+      }
+    });
+
+    p1.fulfill(2);
+    p2.fulfill(3);
+
+    latch.await(2, TimeUnit.SECONDS);
+    assertEquals(result.value, (Integer) 5);
+  }
+  
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  @Test
+  public void testPromiseAllRejectOnTimeout() throws InterruptedException {
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    Promise p1 = new Promise();
+    Promise p2 = new Promise();
+
+    final Result result = new Result();
+
+    Promise.all(100, p1, p2).then(new PromiseAction<List>() {
+      public void call(List l) {
+        //should't be called
+        result.value = l;
+      }
+    },new PromiseAction<Exception>() {
+      public void call(Exception e) {
+        result.value = e;
+      }
+    });
+
+    p1.fulfill(2);
+    latch.await(1, TimeUnit.SECONDS);
+    p2.fulfill(3);
+
+    assertTrue(result.value instanceof TimeoutException);
+  }
+  
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  @Test
+  public void testPromiseAllPassOnTimeout() throws InterruptedException {
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    Promise p1 = new Promise();
+    Promise p2 = new Promise();
+
+    final Result result = new Result();
+
+    Promise.all(100, p1, p2).then(new PromiseAction<List>() {
+      public void call(List l) {
+        //should't be called
+        result.value = l;
+      }
+    },new PromiseAction<Exception>() {
+      public void call(Exception e) {
+        result.value = e;
+      }
+    });
+
+    p1.fulfill(2);
+    p2.fulfill(3);
+    latch.await(1, TimeUnit.SECONDS);
+
+    assertTrue(result.value instanceof List);
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  @Test
+  public void testPromiseAllReject() throws InterruptedException {
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    Promise p1 = new Promise();
+    Promise p2 = new Promise();
+
+    final Result<Exception> result = new Result<Exception>();
+
+    Promise.all(p1, p2).then(new PromiseAction<List>() {
+      public void call(List l) {
+        // not used for this test
+      }
+    }, new PromiseAction<Exception>() {
+      public void call(Exception e) {
+        result.value = e;
+      }
+    });
+
+    p1.fulfill(2);
+    String reason = "Reject Reason";
+    p2.reject(reason);
+
+    latch.await(2, TimeUnit.SECONDS);
+    assertTrue(result.value instanceof Exception);
+    assertTrue(((Exception) result.value).getMessage().contains(reason));
   }
 
   public Promise<String> makePromise(final String value) {

--- a/vertx-promises/vertx-promises-groovy/src/main/groovy/com/darylteo/vertx/promises/groovy/Promise.groovy
+++ b/vertx-promises/vertx-promises-groovy/src/main/groovy/com/darylteo/vertx/promises/groovy/Promise.groovy
@@ -1,7 +1,11 @@
 package com.darylteo.vertx.promises.groovy
 
+import java.util.List;
+
 import com.darylteo.rx.promises.AbstractPromise
+
 import org.vertx.java.core.Handler
+
 import rx.functions.Action0
 import rx.functions.Func1
 
@@ -29,6 +33,35 @@ public class Promise<T> extends AbstractPromise<T> implements Handler<T> {
 
   public <O> Promise<O> fin(Closure<O> onFinally) {
     return this.promise(null, null, onFinally);
+  }
+  
+  
+  /**
+   * Combines multiple promises into a single promise that is resolved when all of the input promises are resolved
+   *
+   * @param promises array of promises
+   * @return Returns a single promise that will be resolved with a list of values,
+   *         each value corresponding to the promise at the same index in the promises array.
+   *         If any of the promises is resolved with a rejection, this resulting promise will
+   *         be rejected with a list of values/exceptions.
+   */
+  public static Promise<List> all(final Promise... promises) {
+    return AbstractPromise._all(Promise.class, promises);
+  }
+  
+  /**
+   * Combines multiple promises into a single promise that is resolved when all of the input promises are resolved,
+   * before an timeout exception occurs. In case of timeout, result promise will be rejected with an TimeoutException
+   *
+   * @param timeout timeout in milliseconds
+   * @param promises array of promises
+   * @return Returns a single promise that will be resolved with a list of values,
+   *         each value corresponding to the promise at the same index in the promises array.
+   *         If any of the promises is resolved with a rejection, this resulting promise will
+   *         be rejected with a list of values/exceptions.
+   */
+  public static Promise<List> all(long timeout, final Promise... promises) {
+    return AbstractPromise._all(Promise.class, timeout, promises);
   }
 
   private <O> Promise<O> promise(Closure<O> onFulfilled, Closure<O> onRejected, Closure<O> onFinally) {

--- a/vertx-promises/vertx-promises-java/src/main/java/com/darylteo/vertx/promises/java/Promise.java
+++ b/vertx-promises/vertx-promises-java/src/main/java/com/darylteo/vertx/promises/java/Promise.java
@@ -1,10 +1,18 @@
 package com.darylteo.vertx.promises.java;
 
-import com.darylteo.rx.promises.AbstractPromise;
-import com.darylteo.vertx.promises.java.functions.*;
+import java.util.List;
+
 import org.vertx.java.core.Handler;
+
 import rx.Observable;
 import rx.functions.Function;
+
+import com.darylteo.rx.promises.AbstractPromise;
+import com.darylteo.vertx.promises.java.functions.FinallyAction;
+import com.darylteo.vertx.promises.java.functions.FinallyFunction;
+import com.darylteo.vertx.promises.java.functions.PromiseAction;
+import com.darylteo.vertx.promises.java.functions.PromiseFunction;
+import com.darylteo.vertx.promises.java.functions.RepromiseFunction;
 
 public class Promise<T> extends AbstractPromise<T> implements Handler<T> {
   public Promise() {
@@ -86,6 +94,36 @@ public class Promise<T> extends AbstractPromise<T> implements Handler<T> {
 
   public Promise<T> fin(FinallyAction onFinally) {
     return this.promise(null, null, onFinally);
+  }
+  
+  /**
+   * Combines multiple promises into a single promise that is resolved when all of the input promises are resolved
+   *
+   * @param promises array of promises
+   * @return Returns a single promise that will be resolved with a list of values,
+   *         each value corresponding to the promise at the same index in the promises array.
+   *         If any of the promises is resolved with a rejection, this resulting promise will
+   *         be rejected with a list of values/exceptions.
+   */
+  @SuppressWarnings({"rawtypes" })
+  public static Promise<List> all(final Promise... promises) {
+    return (Promise<List>) AbstractPromise._all(Promise.class, promises);
+  }
+  
+  /**
+   * Combines multiple promises into a single promise that is resolved when all of the input promises are resolved,
+   * before an timeout exception occurs. In case of timeout, result promise will be rejected with an TimeoutException
+   *
+   * @param timeout timeout in milliseconds
+   * @param promises array of promises
+   * @return Returns a single promise that will be resolved with a list of values,
+   *         each value corresponding to the promise at the same index in the promises array.
+   *         If any of the promises is resolved with a rejection, this resulting promise will
+   *         be rejected with a list of values/exceptions.
+   */
+  @SuppressWarnings({"rawtypes" })
+  public static Promise<List> all(long timeout, final Promise... promises) {
+    return (Promise<List>) AbstractPromise._all(Promise.class, timeout, promises);
   }
 
   @SuppressWarnings("unchecked")

--- a/vertx-promises/vertx-promises-java/src/test/java/com/darylteo/vertx/promises/java/test/PromiseTests.java
+++ b/vertx-promises/vertx-promises-java/src/test/java/com/darylteo/vertx/promises/java/test/PromiseTests.java
@@ -1,15 +1,17 @@
 package com.darylteo.vertx.promises.java.test;
 
-import com.darylteo.vertx.promises.java.Promise;
-import com.darylteo.vertx.promises.java.functions.PromiseAction;
-import com.darylteo.vertx.promises.java.functions.PromiseFunction;
-import com.darylteo.vertx.promises.java.functions.RepromiseFunction;
+import static org.vertx.testtools.VertxAssert.*;
+
+import java.util.List;
+
 import org.junit.Test;
 import org.vertx.java.core.Handler;
 import org.vertx.testtools.TestVerticle;
 
-import static org.vertx.testtools.VertxAssert.assertEquals;
-import static org.vertx.testtools.VertxAssert.testComplete;
+import com.darylteo.vertx.promises.java.Promise;
+import com.darylteo.vertx.promises.java.functions.PromiseAction;
+import com.darylteo.vertx.promises.java.functions.PromiseFunction;
+import com.darylteo.vertx.promises.java.functions.RepromiseFunction;
 
 public class PromiseTests extends TestVerticle {
   @Test
@@ -44,4 +46,70 @@ public class PromiseTests extends TestVerticle {
 
     });
   }
+  
+  
+  
+  @Test
+  public void testAllHandler() {
+    Promise<Long> promise1 = new Promise();
+    Promise<Long> promise2 = new Promise();
+    vertx.setTimer(1000l, promise1);
+    vertx.setTimer(1010l, promise2);
+
+    Promise.all(promise1, promise2).then(new PromiseFunction<List, String>() {
+      @Override
+      public String call(List results) {
+        return "Hello World!";
+      }
+    }).then(new RepromiseFunction<String, String>() {
+      @Override
+      public Promise<String> call(final String t1) {
+        final Promise<String> p = new Promise();
+        vertx.setTimer(1000l, new Handler<Long>() {
+          @Override
+          public void handle(Long event) {
+            p.fulfill(t1.toUpperCase());
+          }
+        });
+
+        return p;
+      }
+    }).then(new PromiseAction<String>() {
+      @Override
+      public void call(String t1) {
+        assertEquals(t1, "HELLO WORLD!");
+        testComplete();
+      }
+
+    });
+  }
+  
+  @Test
+  public void testAllRejectHandler() {
+    Promise<Long> promise1 = new Promise();
+    final Promise<Long> promise2 = new Promise();
+    vertx.setTimer(1000l, promise1);
+    vertx.setTimer(1010l, new Handler<Long>() {
+      @Override
+      public void handle(Long event) {
+        promise2.reject("cannot process"); 
+      }
+    });
+
+    Promise.all(promise1, promise2).then(new PromiseFunction<List, String>() {
+      @Override
+      public String call(List results) {
+        //should not be called
+        return "Hello World!";
+      }
+    },
+    new PromiseAction<Exception>() {
+      @Override
+      public void call(Exception e) {
+        assertTrue(e != null);
+        testComplete();
+      }
+    });
+  }
+  
 }


### PR DESCRIPTION
Hi, we have extended you library with ability to combine the promises with a all-Method, like in JS-Frameworks (e.g. AngularJS).

Examples:

``` java
Promise p1 = ....
Promise p2 = ....
Promise.all(p1, p2).then(....)
```

or with timeout:

``` java
Promise p1 = ....
Promise p2 = ....
Promise.all(1000 /*timeout in ms*/, p1, p2).then(....)
```

It would be great if you accept these changes and publish a new version to maven central
