### PR TITLE
Removes dependency on sonatypeUsername

### DIFF
--- a/gradle/sonatype.gradle
+++ b/gradle/sonatype.gradle
@@ -2,8 +2,8 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 def release = { !project.version.endsWith('-SNAPSHOT') }
-def sonatypeUsername = { project.sonatypeUsername ?: '' }
-def sonatypePassword = { project.sonatypePassword ?: '' }
+def sonatypeUsername = { project.hasProperty('sonatypeUsername') ?: '' }
+def sonatypePassword = { project.hasProperty('sonatypePassword') ?: '' }
 
 configurations { archives }
 


### PR DESCRIPTION
This allows me to build in gradle which wasn't possible before as I don't have those two properties setup.
